### PR TITLE
deprecate nodejs < v8.17, npm < v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
     "lint:js": "npm run lint:eslint -- . ",
     "lint:staged": "lint-staged",
     "prebuild": "npm run build:clean && npm run test",
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "pretest": "npm run lint",
     "release": "npmpub",
     "start": "npm test",


### PR DESCRIPTION
nodejs boron (v6) entered maintenance on 2016-10-18 and EOL since 2019-04-30. It is not considered in active use anymore.

`prepublish` changed to `prepare` for npm v5+